### PR TITLE
Document using expo-yarn-workspaces with EAS Build

### DIFF
--- a/packages/expo-yarn-workspaces/README.md
+++ b/packages/expo-yarn-workspaces/README.md
@@ -22,7 +22,7 @@ Each Expo app in the repository that is intended to work with Yarn workspaces (a
 
 ### Define the entry module in the `"main"` field of each app's package.json
 
-The postinstall script determines the location of the generated entry module by looking at the `"main"` field in package.json. In a conventional Expo app, the value of the `"main"` field is `node_modules/expo/AppEntry.js`. In a workspace in the Expo repo, **specify `"__generated__/AppEntry.js"` as the value of the `"main"` field in package.json.**
+The postinstall script determines the location of the generated entry module by looking at the `"main"` field in package.json. In a conventional Expo app, the value of the `"main"` field is `node_modules/expo/AppEntry.js`. In a workspace in the Expo repo, **specify `"__generated__/AppEntry.js"` as the value of the `"main"` field in package.json.** If using EAS Build, see the additional instructions below.
 
 You can specify other paths too. The `.expo` directory is convenient since it already contains auto-generated files and is .gitignore'd.
 
@@ -67,6 +67,26 @@ Sometimes an npm package must be located in the project's `node_modules` folder 
 {
   "expo-yarn-workspaces": {
     "symlinks": ["react-native-unimodules"]
+  }
+}
+```
+
+## EAS Build integration
+
+You must configure EAS Build to use the generated entrypoint. Add the `ENTRY_FILE` environment variable to your `eas.json` like the following:
+
+```
+{
+  ...
+  "build": {
+    "development": {
+      "developmentClient": true,
+      "distribution": "internal",
+      "env": {
+        "ENTRY_FILE": "./__generated__/AppEntry.js"
+      }
+    },
+    ...
   }
 }
 ```


### PR DESCRIPTION
# Why

Following the README instructions breaks EAS Build. So we should document the fix.

# How

I read the Xcode logs, did a Google search, and then found [this comment](https://github.com/expo/expo/issues/11744#issuecomment-784821966).

# Test Plan

I ran my build with that env. var. and it succeeded where previously it had failed.

# Checklist

This is a documentation-only update. It should not fail `expo build` or `expo prebuild`.

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
